### PR TITLE
Support for style of "Longer text on markers"

### DIFF
--- a/src/StepItem.vue
+++ b/src/StepItem.vue
@@ -2,7 +2,7 @@
   <li class="progress-step" :class="{ 'is-active': isActive, 'is-complete': isComplete }">
     <span class="progress-marker">{{ marker }}</span>
     <span class="progress-text" v-if="title">
-      <h4 class="progress-title">{{ title }}</h4>
+      <h4 class="progress-title">{{ title }}</h4>{{ text }}
       <slot></slot>
     </span>
   </li>
@@ -18,7 +18,8 @@ export default {
       default: ''
     },
     kind: String,
-    title: String
+    title: String,
+    text: String
   },
 
   created () {


### PR DESCRIPTION
There's a style called "Longer text on markers" described as follow by [Progress Tracker](http://nigelotoole.github.io/progress-tracker/):

``` html
<ul class="progress-tracker progress-tracker--text progress-tracker--center">
  <li class="progress-step is-complete">
    <span class="progress-marker"></span>
    <span class="progress-text">
      <h4 class="progress-title">Step 1</h4>
      Summary text explaining this step to the user
    </span>
  </li>
  ...
</ul>
```

But when I try to use this style using this vue component, I had some trouble using this style to add some longger text after `<h4>`, So here I have some adjustments to make the component fit the style, so that I can add the text with single way as follow:

``` xml
<progress-tracker text alignment="center">
  <step-item v-for="item in stepItems" :marker="item.marker" :title="item.title" :text="item.text"></step-item>
</progress-tracker>
```
